### PR TITLE
Webpack v4 compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import hash from 'object-hash';
 
 class IgnoreUnchangedFilesPlugin {
   apply(compiler) {
-    compiler.plugin('emit', (compilation, callback) => {
+    const onEmit = (compilation, callback) => {
       const {
         assets,
       } = compilation;
@@ -31,7 +31,13 @@ class IgnoreUnchangedFilesPlugin {
           cb();
         });
       }, callback);
-    });
+    };
+
+    if (compiler.hooks) {
+      compiler.hooks.emit.tapAsync('ignore-unchanged-webpack-plugin', onEmit);
+    } else {
+      compiler.plugin('emit', onEmit);
+    }
   }
 }
 


### PR DESCRIPTION
In my limited testing as a new webpack user, this plugin already works fine with webpack v4 so all that's needed is to squash the deprecation warning. I expect this change to be fully backwards compatible with older webpack versions.

I'm making this change using the Github web interface so please excuse any silly mistakes or lack of testing!

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
